### PR TITLE
OME-432 Calendar View/Zoom Issue

### DIFF
--- a/JZCalendarWeekView/JZWeekViewFlowLayout.swift
+++ b/JZCalendarWeekView/JZWeekViewFlowLayout.swift
@@ -613,7 +613,8 @@ open class JZWeekViewFlowLayout: UICollectionViewFlowLayout {
                 
             let sectionIndexes = NSIndexSet(indexesIn: NSRange(location: indexPath.section, length: 1))
             prepareHorizontalTileSectionLayoutForSections(sectionIndexes)
-            return itemAttributes[indexPath] == nil ? UICollectionViewLayoutAttributes() : itemAttributes[indexPath]
+            let item = itemAttributes[indexPath] ?? layoutAttributesForCell(at: indexPath, withItemCache: itemAttributes).1[indexPath]
+            return item
         }
         
         return attrs


### PR DESCRIPTION
Addresses potential crashes related to missing layout attributes during collection view updates by providing fallback attributes for appearing/disappearing items and supplementary/decoration views.

Adds logging to track collection view updates.

Fixes a potential nil dereference when accessing `currentTimeComponents`.

Adds a fallback mechanism for `currentEditingInfo.event` in `JZLongPressWeekView` to prevent crashes when the cell cannot be cast to `JZLongPressEventCell`.

Invalidates layout instead of calling `reloadData` to prevent potential conflicts with UIKit's update cycle.

Removes redundant layout attribute overrides.

Removes overridden layout attribute functions.
These functions were likely added for defensive
programming but are now redundant.

Fixes nil attribute return in layout

Addresses an issue where layout attributes for items were sometimes
returning nil, causing layout inconsistencies.

Adds a defensive check to prepare layout if cached attributes
are missing for a specific index path. This ensures that the
collection view attempts to properly layout the cell if its
attributes are not readily available.

Improves layout attribute handling

Ensures that the superclass's layout attributes are always retrieved to prevent potential layout inconsistencies.

This also avoids clearing the attributes cache during animated updates, which resolves UICollectionView issues related to cell attribute consistency during bounds changes.

Refactors layout attributes management

Improves layout performance by centralizing attribute access and management.

Consolidates attribute dictionaries into a computed property for efficient access.

Renames `outscreenCell` to `outScreenCell` for consistency.

Ensures robust layout attribute retrieval

Refactors layout attribute generation and caching logic within `JZWeekViewFlowLayout`.

Previously, `layoutAttributesForItem(at:)` could return an empty `UICollectionViewLayoutAttributes` if an item's attributes were not found in the cache, potentially leading to incorrect layout or crashes. This change now ensures that if attributes are missing, they are properly retrieved or created via `layoutAttributesForCell`.

Additionally, the helper functions for retrieving/creating attributes for cells, decoration views, and supplementary views have been streamlined. They now use clearer Swift syntax to check for existing attributes, create new ones when needed, and correctly update the item cache. This prevents potential `nil` issues and improves the reliability of layout attribute handling.

Improves layout stability and performance

Removes print statements and improves layout attribute handling to prevent crashes and enhance performance during collection view updates.

Specifically, it caches and reuses layout attributes for appearing and disappearing items, supplementary views, and decoration elements. It also provides a default UICollectionViewLayoutAttributes object when the item attribute is nil, preventing potential crashes.

Fixes macOS26