### PR TITLE
Adds image symbol name for zoom configuration

### DIFF
--- a/JZCalendarWeekView/Utils/JZCalendarModel.swift
+++ b/JZCalendarWeekView/Utils/JZCalendarModel.swift
@@ -31,13 +31,18 @@ final public class ZoomConfiguration: NSObject, NSCoding {
         case min, `default`, max
 
         public var image: UIImage? {
+            UIImage(systemName: imageSymbolName)?.withRenderingMode(.alwaysTemplate)
+        }
+        
+        public var imageSymbolName: String {
             switch self {
             case .min, .default:
-                return UIImage(systemName: "plus.magnifyingglass")?.withRenderingMode(.alwaysTemplate)
+                "plus.magnifyingglass"
             case .max:
-                return UIImage(systemName: "minus.magnifyingglass")?.withRenderingMode(.alwaysTemplate)
+                "minus.magnifyingglass"
             }
         }
+            
 
         public var value: (division: JZHourGridDivision, height: CGFloat) {
             switch self {


### PR DESCRIPTION
Introduces `imageSymbolName` property to `ZoomConfiguration` to streamline image retrieval using system symbols.

This change simplifies the zoom configuration process by directly associating a system symbol name with each zoom level.
The `image` property now utilizes the `imageSymbolName` to create the corresponding `UIImage`.
