### PR TITLE
Ensures tap gesture recognition is enabled

### DIFF
--- a/JZCalendarWeekView/JZLongPressWeekView.swift
+++ b/JZCalendarWeekView/JZLongPressWeekView.swift
@@ -722,7 +722,8 @@ open class JZLongPressWeekView: JZBaseWeekView, UIGestureRecognizerDelegate {
         _ gestureRecognizer: UIGestureRecognizer,
         shouldRecognizeSimultaneouslyWith otherGestureRecognizer: UIGestureRecognizer
     ) -> Bool {
-        guard isTapGestureEnabled else { return true }
+        guard isTapGestureEnabled,
+                gestureRecognizer is UITapGestureRecognizer else { return true }
         
         if (gestureRecognizer == doubleTapGesture && otherGestureRecognizer == singleTapGesture) ||
             (gestureRecognizer == singleTapGesture && otherGestureRecognizer == doubleTapGesture) {


### PR DESCRIPTION
Ensures that the `isTapGestureEnabled` flag is checked and that the gesture recognizer is a `UITapGestureRecognizer` before allowing simultaneous recognition with other gesture recognizers. This prevents unexpected behavior when other gesture recognizers are present.
