### PR TITLE
EFF-250 Fix overlapping events being covered in chain-overlap scenarios (#27)

### DIFF
--- a/Example/JZCalendarWeekViewExample/Source/LongPressViews/LongPressEventCell.swift
+++ b/Example/JZCalendarWeekViewExample/Source/LongPressViews/LongPressEventCell.swift
@@ -20,6 +20,9 @@ class LongPressEventCell: JZLongPressEventCell {
         super.awakeFromNib()
 
         setupBasic()
+        // You have to set the background color in contentView instead of cell background color, because cell reuse problems in collectionview
+        // When setting alpha to cell, the alpha will back to 1 when collectionview scrolled, which means that moving cell will not be translucent
+        contentView.backgroundColor = UIColor(hex: 0xEEF7FF)
     }
 
     func setupBasic() {
@@ -38,10 +41,6 @@ class LongPressEventCell: JZLongPressEventCell {
         locationLabel.text = event.location
         titleLabel.text = event.title
         locationLabel.isHidden = isAllDay
-        
-        // You have to set the background color in contentView instead of cell background color, because cell reuse problems in collectionview
-        // When setting alpha to cell, the alpha will back to 1 when collectionview scrolled, which means that moving cell will not be translucent
-        contentView.backgroundColor = UIColor(hex: 0xEEF7FF)
     }
 
 }


### PR DESCRIPTION
https://linear.app/symplast/issue/EFF-250/appt-cut-off-on-calendar-vip-suria

- Make overlap group sorting deterministic with tie-breakers by minY and indexPath
- Process remaining groups by dependency on already-adjusted items instead of
  sequential iteration, so constrained groups are resolved first
- Move contentView background color setup from awakeFromNib to configureCell
  in LongPressEventCell for proper cell reuse handling
- Update tests to use hourHeightForZoomLevel property
- Add JZWeekViewFlowLayoutOverlapTests for chain-overlap regression coverage

| Old | New |
| :--: | :--: |
| <img width="305" height="443" alt="Screenshot 2026-03-26 at 2 32 39 PM" src="https://github.com/user-attachments/assets/594ec512-e969-4d6a-b7ba-a5e9aee79d79" /> | <img width="248" height="320" alt="Screenshot 2026-03-26 at 3 52 50 PM" src="https://github.com/user-attachments/assets/33299d5d-3e5e-4c72-8c06-1cb2b67f396b" /> |

